### PR TITLE
optimize boot time

### DIFF
--- a/picosystem/Cargo.toml
+++ b/picosystem/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+wait-for-serial = []
+
 [dependencies]
 cortex-m = "0.7"
 cortex-m-rt = "0.7"

--- a/picosystem/src/display.rs
+++ b/picosystem/src/display.rs
@@ -79,12 +79,15 @@ impl Display {
             backlight_pin,
             dma_channel,
         };
-        let colors =
-            core::iter::repeat(RawU16::from(Rgb565::BLACK).into_inner()).take(WIDTH * HEIGHT);
-        display
-            .st7789
-            .set_pixels(0, 0, (WIDTH - 1) as u16, (HEIGHT - 1) as u16, colors)
-            .unwrap();
+        // A single clear occasionally fails to clear the screen.
+        for _ in 0..2 {
+            let colors =
+                core::iter::repeat(RawU16::from(Rgb565::BLACK).into_inner()).take(WIDTH * HEIGHT);
+            display
+                .st7789
+                .set_pixels(0, 0, (WIDTH - 1) as u16, (HEIGHT - 1) as u16, colors)
+                .unwrap();
+        }
         display.enable_backlight();
         display
     }

--- a/picosystem/src/hardware.rs
+++ b/picosystem/src/hardware.rs
@@ -48,11 +48,14 @@ impl Hardware {
             clocks.usb_clock,
         );
 
-        // Wait for USB to be ready.
-        delay.delay_ms(500);
-        if usb_logger::connected() {
-            // Wait for serial logger.
-            delay.delay_ms(1000);
+        #[cfg(feature = "wait-for-serial")]
+        {
+            // Wait for USB to be ready.
+            delay.delay_ms(500);
+            if usb_logger::connected() {
+                // Wait for serial logger.
+                delay.delay_ms(1000);
+            }
         }
 
         log::info!("Logging initialized");

--- a/picosystem/src/hardware.rs
+++ b/picosystem/src/hardware.rs
@@ -47,7 +47,14 @@ impl Hardware {
             &mut pac.RESETS,
             clocks.usb_clock,
         );
-        delay.delay_ms(1500);
+
+        // Wait for USB to be ready.
+        delay.delay_ms(500);
+        if usb_logger::connected() {
+            // Wait for serial logger.
+            delay.delay_ms(1000);
+        }
+
         log::info!("Logging initialized");
 
         let sio = hal::sio::Sio::new(pac.SIO);

--- a/picosystem/src/usb_logger.rs
+++ b/picosystem/src/usb_logger.rs
@@ -7,7 +7,7 @@ use log::{Level, Metadata, Record};
 use pico::hal;
 use pico::hal::pac;
 use pico::hal::pac::interrupt;
-use usb_device::{class_prelude::*, prelude::*};
+use usb_device::{class_prelude::*, device::UsbDeviceState, prelude::*};
 use usbd_serial::SerialPort;
 
 /// The USB Device Driver (shared with the interrupt).
@@ -58,6 +58,17 @@ pub fn init(
     unsafe {
         pac::NVIC::unmask(hal::pac::Interrupt::USBCTRL_IRQ);
     };
+}
+
+pub fn connected() -> bool {
+    unsafe {
+        USB_DEVICE
+            .as_ref()
+            .map(|d| {
+                d.state() == UsbDeviceState::Addressed || d.state() == UsbDeviceState::Configured
+            })
+            .unwrap_or(false)
+    }
 }
 
 #[allow(non_snake_case)]


### PR DESCRIPTION
- hardware: only wait for serial logger if USB cable is connected
- display: clear twice to avoid junk on screen
- hardware: move wait for USB under a feature flag
