### PR TITLE
improve draw performance

### DIFF
--- a/games/Cargo.toml
+++ b/games/Cargo.toml
@@ -1,7 +1,9 @@
+cargo-features = ["edition2021"]
+
 [package]
 name = "picosystem_games"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/games/src/hangman.rs
+++ b/games/src/hangman.rs
@@ -105,163 +105,166 @@ fn draw(
     errors: u8,
     letter_index: i32,
 ) {
-    hw.display.clear(Rgb565::BLACK).unwrap();
-    const LETTER_WIDTH: i32 = 10;
+    hw.display.draw(|display| {
+        display.clear(Rgb565::BLACK).unwrap();
+        const LETTER_WIDTH: i32 = 10;
 
-    let mut guess = Word::new();
-    for ch in target.chars() {
-        if guessed.contains(&ch) {
-            guess.push(ch).unwrap();
-        } else {
-            guess.push('_').unwrap();
+        let mut guess = Word::new();
+        for ch in target.chars() {
+            if guessed.contains(&ch) {
+                guess.push(ch).unwrap();
+            } else {
+                guess.push('_').unwrap();
+            }
         }
-    }
-    let text_style = MonoTextStyle::new(&FONT_10X20, Rgb565::WHITE);
-    Text::new(
-        &guess,
-        Point::new((WIDTH as i32 - LETTER_WIDTH * guess.len() as i32) / 2, 160),
-        text_style,
-    )
-    .draw(&mut hw.display)
-    .unwrap();
-
-    let mut letters = heapless::String::<26>::new();
-    let mut crosses = heapless::String::<26>::new();
-    const LETTERS_DISPLAYED: i32 = 9;
-    for i in 0..LETTERS_DISPLAYED {
-        let offset = i - LETTERS_DISPLAYED / 2;
-        let ch = letter_from_index(letter_index + offset);
-        if offset != 0 {
-            letters.push(ch).unwrap();
-        } else {
-            letters.push(' ').unwrap();
-        }
-        if guessed.contains(&ch) {
-            crosses.push('X').unwrap();
-        } else {
-            crosses.push(' ').unwrap();
-        }
-    }
-    Text::new(
-        &letters,
-        Point::new((WIDTH as i32 - LETTERS_DISPLAYED * LETTER_WIDTH) / 2, 200),
-        MonoTextStyle::new(&FONT_10X20, Rgb565::CSS_LIGHT_SLATE_GRAY),
-    )
-    .draw(&mut hw.display)
-    .unwrap();
-
-    letters.clear();
-    letters.push(letter_from_index(letter_index)).unwrap();
-    Text::new(
-        &letters,
-        Point::new((WIDTH as i32 - LETTER_WIDTH) / 2, 199),
-        MonoTextStyle::new(&FONT_10X20, Rgb565::GREEN),
-    )
-    .draw(&mut hw.display)
-    .unwrap();
-
-    Text::new(
-        &crosses,
-        Point::new((WIDTH as i32 - LETTERS_DISPLAYED * LETTER_WIDTH) / 2, 202),
-        MonoTextStyle::new(&FONT_10X20, Rgb565::CSS_DARK_RED),
-    )
-    .draw(&mut hw.display)
-    .unwrap();
-
-    let mid = WIDTH as i32 / 2;
-    let top = 30;
-
-    {
-        let style = PrimitiveStyleBuilder::new()
-            .stroke_color(Rgb565::RED)
-            .stroke_width(1)
-            .build();
-        if errors > 0 {
-            let head = Circle::with_center(Point::new(mid, top + 10), 20).into_styled(style);
-            head.draw(&mut hw.display).unwrap();
-        }
-
-        if errors > 1 {
-            let body =
-                Line::new(Point::new(mid, top + 20), Point::new(mid, top + 60)).into_styled(style);
-            body.draw(&mut hw.display).unwrap();
-        }
-
-        if errors > 2 {
-            let left_arm = Line::new(Point::new(mid, top + 30), Point::new(mid - 15, top + 40))
-                .into_styled(style);
-            left_arm.draw(&mut hw.display).unwrap();
-        }
-
-        if errors > 3 {
-            let right_arm = Line::new(Point::new(mid, top + 30), Point::new(mid + 15, top + 40))
-                .into_styled(style);
-            right_arm.draw(&mut hw.display).unwrap();
-        }
-
-        if errors > 4 {
-            let left_leg = Line::new(Point::new(mid, top + 60), Point::new(mid - 10, top + 80))
-                .into_styled(style);
-            left_leg.draw(&mut hw.display).unwrap();
-        }
-
-        if errors > 5 {
-            let right_leg = Line::new(Point::new(mid, top + 60), Point::new(mid + 10, top + 80))
-                .into_styled(style);
-            right_leg.draw(&mut hw.display).unwrap();
-        }
-    }
-
-    {
-        let style = PrimitiveStyleBuilder::new()
-            .stroke_color(Rgb565::CSS_BROWN)
-            .stroke_width(1)
-            .build();
-
-        Line::new(
-            Point::new(mid - 60, top + 90),
-            Point::new(mid - 20, top + 90),
+        let text_style = MonoTextStyle::new(&FONT_10X20, Rgb565::WHITE);
+        Text::new(
+            &guess,
+            Point::new((WIDTH as i32 - LETTER_WIDTH * guess.len() as i32) / 2, 160),
+            text_style,
         )
-        .into_styled(style)
-        .draw(&mut hw.display)
+        .draw(display)
         .unwrap();
 
-        Line::new(
-            Point::new(mid - 40, top - 10),
-            Point::new(mid - 40, top + 90),
+        let mut letters = heapless::String::<26>::new();
+        let mut crosses = heapless::String::<26>::new();
+        const LETTERS_DISPLAYED: i32 = 9;
+        for i in 0..LETTERS_DISPLAYED {
+            let offset = i - LETTERS_DISPLAYED / 2;
+            let ch = letter_from_index(letter_index + offset);
+            if offset != 0 {
+                letters.push(ch).unwrap();
+            } else {
+                letters.push(' ').unwrap();
+            }
+            if guessed.contains(&ch) {
+                crosses.push('X').unwrap();
+            } else {
+                crosses.push(' ').unwrap();
+            }
+        }
+        Text::new(
+            &letters,
+            Point::new((WIDTH as i32 - LETTERS_DISPLAYED * LETTER_WIDTH) / 2, 200),
+            MonoTextStyle::new(&FONT_10X20, Rgb565::CSS_LIGHT_SLATE_GRAY),
         )
-        .into_styled(style)
-        .draw(&mut hw.display)
+        .draw(display)
         .unwrap();
 
-        Line::new(Point::new(mid - 40, top - 10), Point::new(mid, top - 10))
+        letters.clear();
+        letters.push(letter_from_index(letter_index)).unwrap();
+        Text::new(
+            &letters,
+            Point::new((WIDTH as i32 - LETTER_WIDTH) / 2, 199),
+            MonoTextStyle::new(&FONT_10X20, Rgb565::GREEN),
+        )
+        .draw(display)
+        .unwrap();
+
+        Text::new(
+            &crosses,
+            Point::new((WIDTH as i32 - LETTERS_DISPLAYED * LETTER_WIDTH) / 2, 202),
+            MonoTextStyle::new(&FONT_10X20, Rgb565::CSS_DARK_RED),
+        )
+        .draw(display)
+        .unwrap();
+
+        let mid = WIDTH as i32 / 2;
+        let top = 30;
+
+        {
+            let style = PrimitiveStyleBuilder::new()
+                .stroke_color(Rgb565::RED)
+                .stroke_width(1)
+                .build();
+            if errors > 0 {
+                let head = Circle::with_center(Point::new(mid, top + 10), 20).into_styled(style);
+                head.draw(display).unwrap();
+            }
+
+            if errors > 1 {
+                let body = Line::new(Point::new(mid, top + 20), Point::new(mid, top + 60))
+                    .into_styled(style);
+                body.draw(display).unwrap();
+            }
+
+            if errors > 2 {
+                let left_arm = Line::new(Point::new(mid, top + 30), Point::new(mid - 15, top + 40))
+                    .into_styled(style);
+                left_arm.draw(display).unwrap();
+            }
+
+            if errors > 3 {
+                let right_arm =
+                    Line::new(Point::new(mid, top + 30), Point::new(mid + 15, top + 40))
+                        .into_styled(style);
+                right_arm.draw(display).unwrap();
+            }
+
+            if errors > 4 {
+                let left_leg = Line::new(Point::new(mid, top + 60), Point::new(mid - 10, top + 80))
+                    .into_styled(style);
+                left_leg.draw(display).unwrap();
+            }
+
+            if errors > 5 {
+                let right_leg =
+                    Line::new(Point::new(mid, top + 60), Point::new(mid + 10, top + 80))
+                        .into_styled(style);
+                right_leg.draw(display).unwrap();
+            }
+        }
+
+        {
+            let style = PrimitiveStyleBuilder::new()
+                .stroke_color(Rgb565::CSS_BROWN)
+                .stroke_width(1)
+                .build();
+
+            Line::new(
+                Point::new(mid - 60, top + 90),
+                Point::new(mid - 20, top + 90),
+            )
             .into_styled(style)
-            .draw(&mut hw.display)
+            .draw(display)
             .unwrap();
 
-        Line::new(Point::new(mid, top - 10), Point::new(mid, top))
+            Line::new(
+                Point::new(mid - 40, top - 10),
+                Point::new(mid - 40, top + 90),
+            )
             .into_styled(style)
-            .draw(&mut hw.display)
+            .draw(display)
             .unwrap();
-    }
 
-    hw.display.flush();
+            Line::new(Point::new(mid - 40, top - 10), Point::new(mid, top - 10))
+                .into_styled(style)
+                .draw(display)
+                .unwrap();
+
+            Line::new(Point::new(mid, top - 10), Point::new(mid, top))
+                .into_styled(style)
+                .draw(display)
+                .unwrap();
+        }
+    });
 }
 
 fn animate_win(hw: &mut hardware::Hardware) {
-    Rectangle::new(Point::new(40, 100), Size::new(160, 40))
-        .into_styled(PrimitiveStyle::with_fill(Rgb565::CSS_GREEN))
-        .draw(&mut hw.display)
+    hw.display.draw(|display| {
+        Rectangle::new(Point::new(40, 100), Size::new(160, 40))
+            .into_styled(PrimitiveStyle::with_fill(Rgb565::CSS_GREEN))
+            .draw(display)
+            .unwrap();
+        Text::with_alignment(
+            "You win!",
+            Point::new(120, 127),
+            MonoTextStyle::new(&FONT_10X20, Rgb565::WHITE),
+            Alignment::Center,
+        )
+        .draw(display)
         .unwrap();
-    Text::with_alignment(
-        "You win!",
-        Point::new(120, 127),
-        MonoTextStyle::new(&FONT_10X20, Rgb565::WHITE),
-        Alignment::Center,
-    )
-    .draw(&mut hw.display)
-    .unwrap();
-    hw.display.flush();
+    });
 
     hw.audio.start_tone(440);
     hw.delay.delay_ms(100);
@@ -273,20 +276,21 @@ fn animate_win(hw: &mut hardware::Hardware) {
 }
 
 fn animate_lose(hw: &mut hardware::Hardware) {
-    Rectangle::new(Point::new(40, 100), Size::new(160, 40))
-        .into_styled(PrimitiveStyle::with_fill(Rgb565::CSS_DARK_RED))
-        .draw(&mut hw.display)
+    hw.display.draw(|display| {
+        Rectangle::new(Point::new(40, 100), Size::new(160, 40))
+            .into_styled(PrimitiveStyle::with_fill(Rgb565::CSS_DARK_RED))
+            .draw(display)
+            .unwrap();
+        Text::with_alignment(
+            "You lose!",
+            Point::new(120, 127),
+            MonoTextStyle::new(&FONT_10X20, Rgb565::WHITE),
+            Alignment::Center,
+        )
+        .draw(display)
         .unwrap();
-    Text::with_alignment(
-        "You lose!",
-        Point::new(120, 127),
-        MonoTextStyle::new(&FONT_10X20, Rgb565::WHITE),
-        Alignment::Center,
-    )
-    .draw(&mut hw.display)
-    .unwrap();
+    });
 
-    hw.display.flush();
     hw.audio.start_tone(400);
     hw.delay.delay_ms(100);
     hw.audio.start_tone(200);

--- a/games/src/life.rs
+++ b/games/src/life.rs
@@ -44,23 +44,34 @@ pub fn main(hw: &mut hardware::Hardware) -> ! {
             }
         }
 
-        hw.display.clear(Rgb565::BLUE).unwrap();
-        for y in 0..BOARD_SIZE {
-            for x in 0..BOARD_SIZE {
-                if board.get(x, y) {
-                    let ix = (x * 2) as i32;
-                    let iy = (y * 2) as i32;
-                    Rectangle::new(Point::new(ix, iy), Size::new(2, 2))
-                        .into_styled(
-                            PrimitiveStyleBuilder::new()
-                                .fill_color(Rgb565::WHITE)
-                                .build(),
-                        )
-                        .draw(&mut hw.display)
-                        .unwrap();
+        hw.display.draw(|display| {
+            display.clear(Rgb565::BLUE).unwrap();
+            for y in 0..BOARD_SIZE {
+                for x in 0..BOARD_SIZE {
+                    if board.get(x, y) {
+                        let ix = (x * 2) as i32;
+                        let iy = (y * 2) as i32;
+                        Rectangle::new(Point::new(ix, iy), Size::new(2, 2))
+                            .into_styled(
+                                PrimitiveStyleBuilder::new()
+                                    .fill_color(Rgb565::WHITE)
+                                    .build(),
+                            )
+                            .draw(display)
+                            .unwrap();
+                    }
                 }
             }
-        }
+
+            {
+                let ix = (cursorx * 2) as i32;
+                let iy = (cursory * 2) as i32;
+                Rectangle::new(Point::new(ix, iy), Size::new(2, 2))
+                    .into_styled(PrimitiveStyleBuilder::new().fill_color(Rgb565::RED).build())
+                    .draw(display)
+                    .unwrap();
+            }
+        });
 
         if hw.input.dpad_left.is_held() {
             cursorx = wrap(cursorx - 1);
@@ -80,17 +91,6 @@ pub fn main(hw: &mut hardware::Hardware) -> ! {
         if hw.input.button_y.is_pressed() {
             paused = !paused;
         }
-
-        {
-            let ix = (cursorx * 2) as i32;
-            let iy = (cursory * 2) as i32;
-            Rectangle::new(Point::new(ix, iy), Size::new(2, 2))
-                .into_styled(PrimitiveStyleBuilder::new().fill_color(Rgb565::RED).build())
-                .draw(&mut hw.display)
-                .unwrap();
-        }
-
-        hw.display.flush();
 
         let now = time::time_us();
         if now - prev_time_us > 1_000_000 {

--- a/picosystem/Cargo.toml
+++ b/picosystem/Cargo.toml
@@ -1,7 +1,9 @@
+cargo-features = ["edition2021"]
+
 [package]
 name = "picosystem"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/picosystem/examples/grid.rs
+++ b/picosystem/examples/grid.rs
@@ -1,0 +1,44 @@
+#![no_std]
+#![no_main]
+
+use cortex_m_rt::entry;
+use log::info;
+use picosystem::hardware;
+
+use embedded_graphics::pixelcolor::Rgb565;
+use embedded_graphics::prelude::*;
+use embedded_graphics::primitives::*;
+
+#[link_section = ".boot2"]
+#[used]
+pub static BOOT_LOADER: [u8; 256] = rp2040_boot2::BOOT_LOADER_W25Q080;
+
+#[entry]
+fn main() -> ! {
+    let mut hw = hardware::Hardware::new();
+
+    info!("Finished initialization");
+    let mut x: i32 = 0;
+    let mut y: i32 = 0;
+    loop {
+        hw.display.draw(|display| {
+            display.clear(Rgb565::BLACK).unwrap();
+            for i in 0..240 {
+                if i % 16 == 0 {
+                    Line::new(Point::new(x + i, 0), Point::new(x + i, 239))
+                        .into_styled(PrimitiveStyle::with_stroke(Rgb565::GREEN, 1))
+                        .draw(display)
+                        .unwrap();
+                }
+                if i % 16 == 0 {
+                    Line::new(Point::new(0, y + i), Point::new(239, y + i))
+                        .into_styled(PrimitiveStyle::with_stroke(Rgb565::BLUE, 1))
+                        .draw(display)
+                        .unwrap();
+                }
+            }
+            x = (x + 2) % 16;
+            y = (y + 2) % 16;
+        });
+    }
+}

--- a/picosystem/examples/grid.rs
+++ b/picosystem/examples/grid.rs
@@ -22,7 +22,7 @@ fn main() -> ! {
     let mut y: i32 = 0;
     loop {
         hw.display.draw(|display| {
-            display.clear(Rgb565::BLACK).unwrap();
+            display.clear(Rgb565::CSS_DARK_RED).unwrap();
             for i in 0..240 {
                 if i % 16 == 0 {
                     Line::new(Point::new(x + i, 0), Point::new(x + i, 239))

--- a/picosystem/examples/tunnel.rs
+++ b/picosystem/examples/tunnel.rs
@@ -22,20 +22,17 @@ fn main() -> ! {
 
     let center = Point::new(119, 119);
     let mut sizes: Vec<f32, 32> = Vec::new();
-    let multiplier = 1.01;
-    let initial_size = 1.0;
+    let multiplier = 1.02;
+    let initial_size = 3.0;
     let mut fps_monitor = FpsMonitor::new();
-    let interval = 60;
+    let interval = 25;
     let mut countdown = 0;
 
     loop {
-        for size in sizes.iter_mut() {
-            *size *= multiplier;
-        }
-
         sizes = sizes
             .iter()
             .cloned()
+            .map(|size| size * multiplier)
             .filter(|size| *size < WIDTH as f32)
             .collect();
 
@@ -49,6 +46,7 @@ fn main() -> ! {
         hw.display.draw(|display| {
             display.clear(Rgb565::CSS_DARK_SLATE_BLUE).unwrap();
             for &size in sizes.iter() {
+                let size = size as u32 | 1;
                 Rectangle::with_center(center, Size::new(size as u32, size as u32))
                     .into_styled(PrimitiveStyle::with_stroke(Rgb565::GREEN, 1))
                     .draw(display)

--- a/picosystem/examples/tunnel.rs
+++ b/picosystem/examples/tunnel.rs
@@ -1,0 +1,61 @@
+#![no_std]
+#![no_main]
+
+use cortex_m_rt::entry;
+use embedded_graphics::pixelcolor::Rgb565;
+use embedded_graphics::prelude::*;
+use embedded_graphics::primitives::{PrimitiveStyle, Rectangle};
+use heapless::Vec;
+use log::info;
+use picosystem::display::WIDTH;
+use picosystem::fps_monitor::FpsMonitor;
+use picosystem::hardware;
+
+#[link_section = ".boot2"]
+#[used]
+pub static BOOT_LOADER: [u8; 256] = rp2040_boot2::BOOT_LOADER_W25Q080;
+
+#[entry]
+fn main() -> ! {
+    let mut hw = hardware::Hardware::new();
+    info!("Finished initialization");
+
+    let center = Point::new(119, 119);
+    let mut sizes: Vec<f32, 32> = Vec::new();
+    let multiplier = 1.01;
+    let initial_size = 1.0;
+    let mut fps_monitor = FpsMonitor::new();
+    let interval = 60;
+    let mut countdown = 0;
+
+    loop {
+        for size in sizes.iter_mut() {
+            *size *= multiplier;
+        }
+
+        sizes = sizes
+            .iter()
+            .cloned()
+            .filter(|size| *size < WIDTH as f32)
+            .collect();
+
+        if countdown == 0 {
+            let _ = sizes.push(initial_size);
+            countdown = interval;
+        } else {
+            countdown -= 1;
+        }
+
+        hw.display.draw(|display| {
+            display.clear(Rgb565::CSS_DARK_SLATE_BLUE).unwrap();
+            for &size in sizes.iter() {
+                Rectangle::with_center(center, Size::new(size as u32, size as u32))
+                    .into_styled(PrimitiveStyle::with_stroke(Rgb565::GREEN, 1))
+                    .draw(display)
+                    .unwrap();
+            }
+        });
+
+        fps_monitor.update();
+    }
+}

--- a/picosystem/src/display.rs
+++ b/picosystem/src/display.rs
@@ -96,7 +96,6 @@ impl Display {
     }
 
     fn start_flush(&mut self) {
-        self.wait_for_vsync();
         unsafe {
             dma::start_copy_to_spi(
                 &mut self.dma_channel,
@@ -113,6 +112,7 @@ impl Display {
     }
 
     pub fn flush(&mut self) {
+        self.wait_for_vsync();
         self.start_flush();
         self.wait_for_flush();
     }
@@ -120,6 +120,7 @@ impl Display {
     pub fn draw(&mut self, func: impl FnOnce(&mut Self)) {
         self.wait_for_flush();
         func(self);
+        self.wait_for_vsync();
         self.start_flush();
     }
 

--- a/picosystem/src/dma.rs
+++ b/picosystem/src/dma.rs
@@ -68,7 +68,7 @@ pub(crate) unsafe fn set_mem(
     dma_channel.wait();
 }
 
-pub(crate) unsafe fn copy_to_spi(
+pub(crate) unsafe fn start_copy_to_spi(
     dma_channel: &mut DmaChannel,
     src: u32,
     dst: u32,
@@ -85,5 +85,4 @@ pub(crate) unsafe fn copy_to_spi(
         w.en().set_bit();
         w
     });
-    dma_channel.wait();
 }

--- a/picosystem/src/hardware.rs
+++ b/picosystem/src/hardware.rs
@@ -143,17 +143,17 @@ impl Hardware {
 
         let mut clocks = ClocksManager::new(clocks_dev);
 
-        const PLL_SYS_166MHZ: PLLConfig<Megahertz> = PLLConfig {
-            vco_freq: Megahertz(1500),
+        const PLL_SYS_180MHZ: PLLConfig<Megahertz> = PLLConfig {
+            vco_freq: Megahertz(720),
             refdiv: 1,
-            post_div1: 3,
-            post_div2: 3,
+            post_div1: 4,
+            post_div2: 1,
         };
 
         let pll_sys = setup_pll_blocking(
             pll_sys_dev,
             xosc.operating_frequency().into(),
-            PLL_SYS_166MHZ,
+            PLL_SYS_180MHZ,
             &mut clocks,
             resets,
         )

--- a/picosystem/src/lib.rs
+++ b/picosystem/src/lib.rs
@@ -9,4 +9,5 @@ pub mod input;
 pub mod panic;
 pub mod sprite;
 pub mod time;
+pub mod time_tracker;
 pub mod usb_logger;

--- a/picosystem/src/time_tracker.rs
+++ b/picosystem/src/time_tracker.rs
@@ -1,0 +1,40 @@
+use crate::time;
+use log::info;
+
+pub struct TimeTracker {
+    name: &'static str,
+    last_display_us: u32,
+    accumulated_us: u32,
+    count: u32,
+}
+
+impl TimeTracker {
+    pub fn new(name: &'static str) -> Self {
+        Self {
+            name,
+            last_display_us: 0,
+            accumulated_us: 0,
+            count: 0,
+        }
+    }
+
+    pub fn run<F: FnOnce() -> ()>(&mut self, func: F) {
+        let start = time::time_us();
+        func();
+        let end = time::time_us();
+        let elapsed = end - start;
+        self.accumulated_us += elapsed;
+        self.count += 1;
+        if end - self.last_display_us >= 1_000_000 {
+            info!(
+                "TimeTracker {}: {} us/call {} us/sec",
+                &self.name,
+                self.accumulated_us / self.count,
+                (self.accumulated_us * 1000) / ((end - self.last_display_us) / 1000)
+            );
+            self.last_display_us = end;
+            self.count = 0;
+            self.accumulated_us = 0;
+        }
+    }
+}

--- a/picosystem/src/time_tracker.rs
+++ b/picosystem/src/time_tracker.rs
@@ -18,7 +18,7 @@ impl TimeTracker {
         }
     }
 
-    pub fn run<F: FnOnce() -> ()>(&mut self, func: F) {
+    pub fn run<F: FnOnce()>(&mut self, func: F) {
         let start = time::time_us();
         func();
         let end = time::time_us();

--- a/picosystem_macros/Cargo.toml
+++ b/picosystem_macros/Cargo.toml
@@ -1,7 +1,9 @@
+cargo-features = ["edition2021"]
+
 [package]
 name = "picosystem_macros"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
- add draw API with asynchronous flush
- add tunnel example to test vsync
- add TimeTracker class
- switch to 2021 edition
- tunnel: enhance demo
- add grid example
- hardware: overclock CPU to 166 MHz and SPI to 83 MHz
- hardware: bump CPU clock to 180 MHz and SPI to 90 MHz
- grid: add colored background
- display: move wait_for_vsync out of start_flush
