### PR TITLE
# Fixes:

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,3 @@
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [workspace]
 resolver = "2"
 members = [
@@ -8,10 +6,6 @@ members = [
     "compressor",
 ]
 exclude = ["picosystem_macros"]
-
-[patch.crates-io]
-rp2040-pac = { git = "https://github.com/rp-rs/rp2040-pac.git" }
-rp2040-boot2 = { git = "https://github.com/rlane/rp2040-boot2.git", branch="clkdiv" }
 
 # cargo build/run
 [profile.dev]

--- a/games/Cargo.toml
+++ b/games/Cargo.toml
@@ -9,16 +9,17 @@ edition = "2021"
 cortex-m = "0.7.4"
 cortex-m-rt = "0.7.1"
 embedded-hal = "0.2.7"
-embedded-time = "0.12.1"
-rp-pico = { git = "https://github.com/rp-rs/rp-hal.git", branch="main" }
-rp2040-boot2 = { git = "https://github.com/rp-rs/rp2040-boot2-rs", branch="main" }
-rp2040-hal = { git = "https://github.com/rp-rs/rp-hal", branch="main", features=["rt"] }
-rp2040-pac = { git = "https://github.com/rp-rs/rp2040-pac.git" }
+fugit = "0.3.5"
+rp-pico = "0.7"
+rp2040-boot2 = "0.3"
+rp2040-hal = "0.8"
+rp2040-pac = "0.4"
 log = "0.4.14"
-embedded-graphics = "0.7.1"
+embedded-graphics = "0.8.0"
 oorandom = "11.1.3"
 heapless = "0.7.10"
 picosystem = { path = "../picosystem" }
 micromath = { version = "2.0.0", features = ["vector"] }
 picosystem_macros = { path = "../picosystem_macros" }
 hash32 = "0.2.1"
+u8g2-fonts = { version = "0.3.0", features = ["embedded_graphics_textstyle"] }

--- a/games/src/blob.rs
+++ b/games/src/blob.rs
@@ -493,8 +493,8 @@ fn make_level(level: usize) -> Vec<Wall, 64> {
                     .push(Wall {
                         bounding_box: BoundingBox::new(
                             I32x2 {
-                                x: x as i32 * WALL_SIZE,
-                                y: y as i32 * WALL_SIZE,
+                                x: x * WALL_SIZE,
+                                y: y * WALL_SIZE,
                             },
                             I32x2 {
                                 x: WALL_SIZE,

--- a/games/src/life.rs
+++ b/games/src/life.rs
@@ -163,7 +163,13 @@ fn update(prev_board: &Board, x: usize, y: usize) -> bool {
     for dx in -1..=1 {
         for dy in -1..=1 {
             if dx != 0 || dy != 0 {
-                count += prev_board.get(x + dx as usize, y + dy as usize) as i32
+                let x2 = x as i32 + dx;
+                let y2 = y as i32 + dy;
+                if x2 >= 0 && y2 >= 0 {
+                    let prev =
+                        prev_board.get(x2.try_into().unwrap(), y2.try_into().unwrap()) as i32;
+                    count += prev;
+                }
             }
         }
     }

--- a/games/src/main.rs
+++ b/games/src/main.rs
@@ -7,6 +7,7 @@ mod hangman;
 mod invaders;
 mod life;
 mod mathemagic;
+mod music;
 mod maze;
 mod memory;
 mod system;
@@ -55,7 +56,6 @@ fn main() -> ! {
             name: "life",
             main: life::main,
         },
-        #[cfg(feature = "music")]
         MenuItem {
             name: "music",
             main: music::main,

--- a/games/src/mathemagic/mod.rs
+++ b/games/src/mathemagic/mod.rs
@@ -14,14 +14,12 @@ atlas!(atlas, "games/src/mathemagic/terrain_atlas.png", 32);
 
 sprite!(protagonist, "games/src/mathemagic/lidia.png", 576);
 
-const _: &[u8] = include_bytes!("../../assets/slime/slime_monster_spritesheet.png");
 sprite!(
     slime_atlas,
     "games/assets/slime/slime_monster_spritesheet.png",
     72
 );
 
-const _: &[u8] = include_bytes!("map.tmx");
 map!(worldmap, "games/src/mathemagic/map.tmx");
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/games/src/maze.rs
+++ b/games/src/maze.rs
@@ -22,7 +22,7 @@ fn draw_cell(display: &mut display::Display, point: Point, cell: Cell, inner_col
     let ne = nw + Point::new(MAZE_SCALE, 0);
     let sw = nw + Point::new(0, MAZE_SCALE);
     Rectangle::new(
-        nw + Point::new(MAZE_SCALE as i32 / 4, MAZE_SCALE as i32 / 4),
+        nw + Point::new(MAZE_SCALE / 4, MAZE_SCALE / 4),
         Size::new(MAZE_SCALE as u32 / 2, MAZE_SCALE as u32 / 2),
     )
     .into_styled(PrimitiveStyleBuilder::new().fill_color(inner_color).build())

--- a/games/src/tanks.rs
+++ b/games/src/tanks.rs
@@ -247,7 +247,7 @@ fn fire_shot(
                     continue;
                 }
                 terrain[point.x as usize] =
-                    core::cmp::min(terrain[point.x as usize], HEIGHT as i32 - point.y as i32);
+                    core::cmp::min(terrain[point.x as usize], HEIGHT as i32 - point.y);
             }
 
             let other_p = F32x2 {

--- a/picosystem/Cargo.toml
+++ b/picosystem/Cargo.toml
@@ -12,19 +12,19 @@ wait-for-serial = []
 cortex-m = "0.7.4"
 cortex-m-rt = "0.7.1"
 embedded-hal = "0.2.7"
-embedded-time = "0.12.1"
-rp-pico = { git = "https://github.com/rp-rs/rp-hal.git", branch="main" }
-rp2040-boot2 = { git = "https://github.com/rp-rs/rp2040-boot2-rs", branch="main" }
-rp2040-hal = { git = "https://github.com/rp-rs/rp-hal", branch="main", features=["rt"] }
-rp2040-pac = { git = "https://github.com/rp-rs/rp2040-pac.git" }
+fugit = "0.3.5"
+rp-pico = "0.7.0"
+rp2040-boot2 = "0.3.0"
+rp2040-hal = "0.8.2"
+rp2040-pac = "0.4.0"
 usb-device = "0.2.8"
-usbd-hid = "0.5.2"
+usbd-hid = "0.6.1"
 usbd-serial = "0.1.1"
 log = "0.4.14"
 display-interface = "0.4.1"
 display-interface-spi = "0.4.1"
-embedded-graphics = "0.7.1"
-st7789 = "0.6.1"
+embedded-graphics = "0.8.0"
+st7789 = "0.7.0"
 oorandom = "11.1.3"
 heapless = "0.7.10"
 picosystem_compressor = { path = "../compressor" }

--- a/picosystem/src/idle.rs
+++ b/picosystem/src/idle.rs
@@ -1,3 +1,5 @@
+use cortex_m::delay::Delay;
+
 use crate::{display, input, interrupts, time};
 
 const IDLE_TIME_US: u64 = 300_000_000;
@@ -24,8 +26,8 @@ impl Idle {
         false
     }
 
-    pub fn enter_idle(&mut self, display: &mut display::Display) {
-        display.disable_backlight();
+    pub fn enter_idle(&mut self, display: &mut display::Display, delay: &mut Delay) {
+        display.disable_backlight(delay);
         unsafe {
             let inputs = 16..24;
             for gpio in inputs.clone() {
@@ -39,7 +41,7 @@ impl Idle {
                 interrupts::disable_gpio_interrupt(gpio, interrupts::GpioEvent::EdgeLow);
             }
         }
-        display.enable_backlight();
+        display.enable_backlight(delay);
         self.last_active_time = time::time_us64();
     }
 }

--- a/picosystem/src/sprite.rs
+++ b/picosystem/src/sprite.rs
@@ -49,7 +49,7 @@ impl ImageDrawable for Sprite<'_> {
             {
                 let start_index = area.top_left.x as usize + (y * self.size.width as i32) as usize;
                 let end_index = start_index + area.size.width as usize;
-                for (x, p) in (&self.data[start_index..end_index]).iter().enumerate() {
+                for (x, p) in self.data[start_index..end_index].iter().enumerate() {
                     if *p != transparent_color {
                         let pixels = [Pixel(
                             Point::new(x as i32, iy as i32),

--- a/picosystem/src/tile.rs
+++ b/picosystem/src/tile.rs
@@ -138,7 +138,7 @@ mod device {
                     clipped_dst.size.width / 2,
                 );
                 src_ptr = src_ptr.add(TILE_SIZE as usize);
-                dst_ptr = dst_ptr.add(WIDTH as usize);
+                dst_ptr = dst_ptr.add(WIDTH);
             }
         }
 
@@ -197,7 +197,7 @@ mod device {
                     x += n;
                 }
                 src_ptr = src_ptr.add(TILE_SIZE as usize - x as usize);
-                dst_ptr = dst_ptr.add(WIDTH as usize - x as usize);
+                dst_ptr = dst_ptr.add(WIDTH - x as usize);
                 mask_ptr = mask_ptr.add(1);
             }
             dma_channel.wait();
@@ -259,7 +259,7 @@ mod device {
         loop {
             let progress = display.flush_progress();
             let safe_y = (progress as i32 - WIDTH as i32 + 1) / WIDTH as i32;
-            if safe_y - drawn_y < 32 && progress < (WIDTH * HEIGHT) as usize {
+            if safe_y - drawn_y < 32 && progress < (WIDTH * HEIGHT) {
                 continue;
             } else if safe_y - drawn_y > 64 {
                 slow_draw = true;

--- a/picosystem_macros/Cargo.toml
+++ b/picosystem_macros/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 
 [lib]
 proc-macro = true
+crate-type = ["proc-macro"]
 
 [dependencies]
 log = "0.4.14"
@@ -16,7 +17,7 @@ image = "0.24.1"
 structopt = "0.3.26"
 rustfmt-wrapper = "0.1.0"
 glob = "0.3.0"
-syn = "1.0.86"
+syn = "1.0.109" # keep this at 1.0.x
 picosystem_compressor = { path = "../compressor" }
-picosystem = { path = "../picosystem" }
-tiled = "0.10.0"
+# picosystem = { path = "../picosystem" }
+tiled = "0.11.1"

--- a/picosystem_macros/src/map.rs
+++ b/picosystem_macros/src/map.rs
@@ -1,10 +1,23 @@
-use picosystem::map::{MapTile, INVALID_TILE, NUM_LAYERS};
-use picosystem::tile::TILE_SIZE;
+use std::env;
+use std::path::PathBuf;
 use proc_macro::TokenStream;
+use tiled::Loader;
 use std::collections::HashSet;
-use std::path::Path;
 use syn::parse::{Parse, ParseStream, Result};
 use syn::{parse_macro_input, Ident, LitStr, Token};
+
+// local copy of constants from picosystem::map and picosystem::tile to avoid circular references.
+// If you change them there update them here as well.
+// Don't want to go to the trouble of introducing a common constants module for 3 numbers
+const INVALID_TILE: u16 = !0;
+const NUM_LAYERS: usize = 4;
+const TILE_SIZE: i32 = 32;
+
+// local copy of MapTile struct. same reason as above
+#[derive(Debug)]
+struct MapTile {
+    pub layers: [u16; NUM_LAYERS],
+}
 
 struct MapArgs {
     function_name: Ident,
@@ -29,11 +42,11 @@ pub fn map(input: TokenStream) -> TokenStream {
         path,
     } = parse_macro_input!(input as MapArgs);
 
-    let map = tiled::Map::parse_file(
-        &Path::new(&path.value()),
-        &mut tiled::FilesystemResourceCache::new(),
-    )
-    .expect("Failed to parse map");
+    let mut loader = Loader::new();
+    let mut fullpath = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    fullpath.pop();
+    fullpath.push(path.value());
+    let map = loader.load_tmx_map(&fullpath).expect("Failed to parse map");
 
     assert_eq!(map.tile_width, TILE_SIZE as u32);
     assert_eq!(map.tile_height, TILE_SIZE as u32);
@@ -45,7 +58,7 @@ pub fn map(input: TokenStream) -> TokenStream {
     let mut used_tile_functions: HashSet<u16> = HashSet::new();
     for layer in map.layers() {
         let mut tile_index_layer = Vec::<u16>::new();
-        if let tiled::LayerType::TileLayer(tiled::TileLayer::Finite(tile_layer)) =
+        if let tiled::LayerType::Tiles(tiled::TileLayer::Finite(tile_layer)) =
             &layer.layer_type()
         {
             for y in 0..tile_layer.height() {


### PR DESCRIPTION
- Fixed crash in music game and enabled it in menu
- Fixed crash in Life game
- Fixed crash in invaders game when ships explode
- Fixed missing sprites in invaders
- Fixed mathemagic crash caused by errors in macros that do not create sprite or tile data
- Fixed cyclic references in sprite and tile macros
- Fixed embedding error in sprite and tile macros; they are now embedded with the code, not in a separate section
- Fixed macros not being built because intermediate files were not found during the build process

# Updated the following libraries:
- rp-pico to version 0.7
- rp2040-boot2 to version 0.3
- rp2040-hal to version 0.8
- rp2040-pac to version 0.4
- embedded-graphics was updated to version 0.8.0
- usb-hid to version 0.6.1

# Updated the following libraries with code changes due to broken API:
- Replaced deprecated embedded-time library with fugit version 0.3.5 (successor) and made necessary code changes
- Updated tiled to version 0.11.1 and made necessary code changes
- Updated st7789 to version 0.7.0 and made necessary code changes